### PR TITLE
Fix fatal error when using $host->all_hostnames() and there are no hostnames.

### DIFF
--- a/Parser.pm
+++ b/Parser.pm
@@ -752,7 +752,7 @@ sub hostname {
     return $self->{hostnames}[$index] if ( scalar @{ $self->{hostnames} } );
 }
 
-sub all_hostnames    { return @{ $_[0]->{hostnames} }; }
+sub all_hostnames    { return @{ $_[0]->{hostnames} || [] }; }
 sub extraports_state { return $_[0]->{ports}{extraports}{state}; }
 sub extraports_count { return $_[0]->{ports}{extraports}{count}; }
 sub distance         { return $_[0]->{distance}; }


### PR DESCRIPTION
Basic test for undefined (or false) and use an empty array ref (`[]`) instead. Better choice would be to use the defined-or operator (`//`), but it's a newer feature. This way is more backwards-compatible with older Perl versions.
