### PR TITLE
Fixes issue #4 (Nmap XML format changed)

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Latest version: http://code.google.com/p/nmap-parser/
 
 Website:	http://anthonypersaud.com/
 
+Changes for 1.22
+    - Allow osclass elements within osmatch, Nmap XML format changed in 6.00
+
 Changes for 1.21
     - Added support for hostscript and script tags
     - Changed ipv4_sort() to use a 10x faster sort method

--- a/Parser.pm
+++ b/Parser.pm
@@ -5,7 +5,7 @@ use XML::Twig;
 use Storable qw(dclone);
 use vars qw($VERSION %D);
 
-$VERSION = 1.21;
+$VERSION = 1.22;
 
 
 sub new {
@@ -472,6 +472,7 @@ sub __host_os_tag_hdlr {
     my $portused_tag;
     my $os_fingerprint;
 
+    #if( $D{$$}{SESSION}{xml_version} eq "1.04")
     if ( defined $os_tag ) {
 
         #get the open port used to match os
@@ -492,17 +493,30 @@ sub __host_os_tag_hdlr {
 
         #This will go in Nmap::Parser::Host::OS
         my $osmatch_index = 0;
+        my $osclass_index = 0;
         for my $osmatch ( $os_tag->children('osmatch') ) {
             $os_hashref->{osmatch_name}[$osmatch_index] =
               $osmatch->{att}->{name};
             $os_hashref->{osmatch_name_accuracy}[$osmatch_index] =
               $osmatch->{att}->{accuracy};
             $osmatch_index++;
+            for my $osclass ( $osmatch->children('osclass') ) {
+                $os_hashref->{osclass_osfamily}[$osclass_index] =
+                  $osclass->{att}->{osfamily};
+                $os_hashref->{osclass_osgen}[$osclass_index] =
+                  $osclass->{att}->{osgen};
+                $os_hashref->{osclass_vendor}[$osclass_index] =
+                  $osclass->{att}->{vendor};
+                $os_hashref->{osclass_type}[$osclass_index] =
+                  $osclass->{att}->{type};
+                $os_hashref->{osclass_class_accuracy}[$osclass_index] =
+                  $osclass->{att}->{accuracy};
+                $osclass_index++;
+            }
         }
         $os_hashref->{'osmatch_count'} = $osmatch_index;
 
         #parse osclass tags
-        my $osclass_index = 0;
         for my $osclass ( $os_tag->children('osclass') ) {
             $os_hashref->{osclass_osfamily}[$osclass_index] =
               $osclass->{att}->{osfamily};


### PR DESCRIPTION
From the Nmap changelog:

```
o In XML output, "osclass" elements are now child elements of the
  "osmatch" they belong to. Old output was thus (we're using square
  brackets instead of angle brackets in this CHANGELOG entry to avoid
  html escaping problems:
    [os][osclass/][osclass/]...[osmatch/][osmatch/]...[/os]
  New output is:
    [os][osmatch][osclass/][osclass/]...[/osmatch]...[/os]
  The option --deprecated-xml-osclass restores the old output, in case
  you use an Nmap XML parser that doesn't understand the new
  structure. The xmloutputversion has been increased to 1.04.
```

This commit can handle both new and old formats, and does not change the Nmap-Parser API at all.
